### PR TITLE
fix leaky rawDoc path

### DIFF
--- a/lib/connect_middleware.js
+++ b/lib/connect_middleware.js
@@ -128,7 +128,7 @@ function Middleware(runner) {
       if (rawDocPath) {
         try {
           if (!req.path) { req.path = Url.parse(req.url).path }
-          if (rawDocPath.indexOf(req.path) != -1) {
+          if ( rawDocPath == req.path ) {
             var accept = req.headers['accept'];
             if (accept && accept.indexOf('yaml') != -1) {
               res.setHeader('Content-Type', 'application/yaml');


### PR DESCRIPTION
rawDoc path is checked with
> if (rawDocPath.indexOf(req.path) != -1) {

This means that for path definition **raw: /swagger** matches include:
>/
>/s
>/sw
>/swa
>/swag
>/swagg
>/swagge
>/swagger

This can't possibly be intentional, can it?

Using **==** has the same function without polluting the shorter paths