### PR TITLE
Made Assignment of `json` to `res` conditional

### DIFF
--- a/lib/connect_middleware.js
+++ b/lib/connect_middleware.js
@@ -208,11 +208,13 @@ function expressCompatibility(req, res, next) {
     req.query = url.query;
   }
 
-  res.json = function(obj) {
+  if (!res.json) {
+   res.json = function(obj) {
     res.statusCode = res.statusCode || 200;
     res.setHeader('Content-Type', 'application/json');
     res.end(JSON.stringify(obj));
-  };
+   };
+  }
 
   if (!req.get) req.get = function(name) {
     return this.headers[name];


### PR DESCRIPTION
Assigning `json` to `res`, only if it is not already defined. Otherwise it could make Express apps behave in an unexpected way.

Fixes #255 in `swagger-node`.