### PR TITLE
Add support for enabling SwaggerUI by config

### DIFF
--- a/lib/connect_middleware.js
+++ b/lib/connect_middleware.js
@@ -23,7 +23,7 @@
  ****************************************************************************/
 'use strict';
 
-var debug = require('debug')('swagger');
+var debug = require('debug')('swagger-runner:connect');
 var Url = require('url');
 var CORS = require('cors');
 var YAML = require('js-yaml');
@@ -43,6 +43,10 @@ function Middleware(runner) {
   this.runner = runner;
   this.config = runner.config;
   this.sysConfig = runner.config.swagger;
+
+  var controllers = this.sysConfig.mockMode
+    ? this.sysConfig.mockControllersDirs
+    : this.sysConfig.controllersDirs;
 
   this.metadata = function metadata() {
 
@@ -66,8 +70,6 @@ function Middleware(runner) {
 
   this.router = function router() {
 
-    var controllers = this.sysConfig.mockMode ? this.sysConfig.mockControllersDirs : this.sysConfig.controllersDirs;
-
     var routerConfig = {
       useStubs: !!this.sysConfig.mockMode,
       controllers: controllers
@@ -75,6 +77,17 @@ function Middleware(runner) {
     debug('swaggerTools router config: %j', routerConfig);
     return this.runner.swaggerTools.swaggerRouter(routerConfig);
   };
+
+  this.ui = function ui() {
+
+    var uiConfig = {
+      useStubs: !!this.sysConfig.mockMode,
+      controllers: controllers
+    };
+    debug('swaggerTools UI config: %j', uiConfig);
+    return this.runner.swaggerTools.swaggerUi(uiConfig);
+  };
+
 
   this.jsonErrorHandler = function() {
 
@@ -173,7 +186,6 @@ function Middleware(runner) {
   };
 
   this.stack = function stack(includeErrorHandler) {
-
     includeErrorHandler = includeErrorHandler === undefined || !!includeErrorHandler;
 
     var middlewares = [
@@ -194,6 +206,11 @@ function Middleware(runner) {
 
     if (this.sysConfig.docEndpoints && this.sysConfig.docEndpoints.raw) {
       middlewares.push(this.swaggerDoc());
+    }
+
+    debug('SwaggerUI: ' + (this.sysConfig.swaggerUI ? 'enabled' : 'disabled'));
+    if (this.sysConfig.swaggerUI) {
+      middlewares.push(this.ui());
     }
 
     return middlewares;


### PR DESCRIPTION

Set `SwaggerUI: boolean` to enable

```
// file ./app.js
var config = {
  appRoot: __dirname, // required config
  swaggerUI: true
};
```

```
# file: ./config/default.yaml
# swagger configuration file

# values in the swagger hash are system configuration for swagger
swagger:
  mapErrorsToJson: true
  docEndpoints:
    raw: /swagger
  swaggerUI: true
# any other values in this file are just loaded into the config for application access...
```

https://github.com/theganyo/swagger-node-runner/issues/4
