### PR TITLE
Restify middleware: calling next on success

### DIFF
--- a/lib/restify_middleware.js
+++ b/lib/restify_middleware.js
@@ -28,6 +28,7 @@ function Middleware(runner) {
             res.statusCode = 404;
             res.end('Not found');
           }
+          next();
         });
       });
     });

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "mocha-lcov-reporter": "^1.0.0",
     "restify": "^4.0.3",
     "should": "^7.1.0",
+    "sinon": "^1.17.2",
     "supertest": "^1.1.0"
   },
   "scripts": {

--- a/test/assets/project/api/mocks/hello_world.js
+++ b/test/assets/project/api/mocks/hello_world.js
@@ -4,6 +4,7 @@ module.exports = {
   hello_mock: hello_mock
 };
 
-function hello_mock(req, res) {
+function hello_mock(req, res, next) {
   res.json({ message: 'mocking from the controller!'});
+  next();
 }

--- a/test/lib/restify_middleware.js
+++ b/test/lib/restify_middleware.js
@@ -4,6 +4,7 @@ var should = require('should');
 var request = require('supertest');
 var path = require('path');
 var _ = require('lodash');
+var sinon = require('sinon');
 
 var SwaggerRunner = require('../..');
 
@@ -34,9 +35,25 @@ describe('restify_middleware', function() {
   });
 
   describe('mock', function() {
+    var afterEvent;
 
     before(function(done) {
       createServer.call(this, MOCK_CONFIG, done);
+      afterEvent = sinon.spy();
+      this.app.on('after', afterEvent);
+    });
+
+    describe('after event', function () {
+      it('should been emitted', function (done) {
+        request(this.app)
+          .get('/hello')
+          .set('Accept', 'application/json')
+          .expect(200)
+          .end(function(err, res) {
+            sinon.assert.called(afterEvent);
+            done();
+          });
+      });
     });
 
     after(function(done) {


### PR DESCRIPTION
Hi there,

if you don't call `next();` at the end of the chain callback, the `after` event from Restify will never fire for success (or 404) outcomes and audit logs won't show.

The register method should look like this:

```javascript
  this.register = function register(app) {

    // this bit of oddness forces Restify to route all requests through the middleware
    ALL_METHODS.forEach(function(method) {
      app[method]('.*', function(req, res, next) {
        req.query = undefined; // oddly, req.query is a function in Restify, kill it
        chain(req, res, function(err) {
          if (err) { return next(err); }
          if (!res.finished) {
            res.statusCode = 404;
            res.end('Not found');
          }
          next(); // <--- here I am
        });
      });
    });

    connectMiddleware.register(app);
  };
```

Without the explicit call to `next`, [line 713 from Restfiy's server.js](https://github.com/restify/node-restify/blob/4.x/lib/server.js#L713) won't be executed.

I wrote a test to show the issue.
