### PR TITLE
Stop search when first controller is found

### DIFF
--- a/fittings/swagger_router.js
+++ b/fittings/swagger_router.js
@@ -48,6 +48,7 @@ module.exports = function create(fittingDef, bagpipes) {
           controller = require(controllerPath);
           controllerFunctionsCache[controllerName] = controller;
           debug('controller found', controllerPath);
+          break;
         } catch (err) {
           if (!mockMode && i === controllersDirs.length - 1) {
             return cb(err);


### PR DESCRIPTION
When multiple controllersDirs are used, the first call to swagger_router will
load the cache with the right controller, but return an error if the controller
was not the last in the list.  Instead, break out of the loop when the match
is found.