### PR TITLE
fix sails status code 4xx instead of 500 on non allowed verb (issue #29)

### DIFF
--- a/lib/connect_middleware.js
+++ b/lib/connect_middleware.js
@@ -30,6 +30,7 @@ function Middleware(runner) {
           var msg = util.format('Path [%s] defined in Swagger, but %s operation is not.', path.path, req.method);
           var err = new Error(msg);
           err.statusCode = 405;
+          err.status = err.statusCode;
 
           var allowedMethods = _.map(path.operationObjects, function(operation) {
             return operation.method.toUpperCase();


### PR DESCRIPTION
This will use api/responses/badRequest.js to return 400 statusCode.

If project want exact status code, api/responses/badRequest.js line
function badRequest(data, options) {
...
  res.status(400);
...
can be changed with exact status code from data.statusCode
