### PR TITLE
Adds console logging for validation errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,6 +238,14 @@ function Runner(appJsConfig, cb) {
     })
     .catch(function(err) {
       console.error('Error in callback! Tossing to global error handler.', err.stack);
+
+      if (err.validationErrors) {
+        console.error('Details: ');
+        for (var i= 0; i<err.validationErrors.length; i++) {
+          console.error("\t#" + i + ".: " + err.validationErrors[i].message + " in swagger config at: >" + err.validationErrors[i].path.join('/') + "<");
+        }
+      }
+      
       process.nextTick(function() { throw err; });
     })
 }


### PR DESCRIPTION
Hi Scott.

I recently stumbled on some swagger issues in my yaml file which was just shown as "Error in callback! Tossing to global error handler. Error: Swagger validation errors:"

So I implemented a better logging to console.error pointing the user directly to where the errors occured. 
Adds console logging to console.error that points the user directly to erroneous configuration in their swagger config.

I hope this is feasible...

Thanks, Marius