### PR TITLE
Upgrade Sway dependency to 1.0.0 release

### DIFF
--- a/fittings/swagger_router.js
+++ b/fittings/swagger_router.js
@@ -81,12 +81,12 @@ module.exports = function create(fittingDef, bagpipes) {
       var statusCode = parseInt(context.request.get('_mockreturnstatus')) || 200;
 
       var mimetype = context.request.get('accept') || 'application/json';
-      var mock = operation.getResponseExample(statusCode, mimetype);
+      var mock = operation.getResponse(statusCode).getExample(mimetype);
 
       if (mock) {
         debug('returning mock example value', mock);
       } else {
-        mock = operation.getResponseSample(statusCode);
+        mock = operation.getResponse(statusCode).getSample();
         debug('returning mock sample value', mock);
       }
 

--- a/lib/connect_middleware.js
+++ b/lib/connect_middleware.js
@@ -160,7 +160,7 @@ function hookResponseForValidation(context, eventEmitter) {
         var headers = res._headers || res.headers || {};
         var body = data || written;
         debugContent('response body type: %s value: %s', typeof body, body);
-        var validateResult = context.request.swagger.operation.validateResponse(res.statusCode, headers, body);
+        var validateResult = context.request.swagger.operation.validateResponse({statusCode: res.statusCode, headers, body});
         debug('validation result:', validateResult);
         if (validateResult.errors.length || validateResult.warnings.length) {
           debug('emitting responseValidationError');

--- a/lib/connect_middleware.js
+++ b/lib/connect_middleware.js
@@ -160,7 +160,11 @@ function hookResponseForValidation(context, eventEmitter) {
         var headers = res._headers || res.headers || {};
         var body = data || written;
         debugContent('response body type: %s value: %s', typeof body, body);
-        var validateResult = context.request.swagger.operation.validateResponse({statusCode: res.statusCode, headers, body});
+        var validateResult = context.request.swagger.operation.validateResponse({
+          statusCode: res.statusCode,
+          headers: headers,
+          body: body
+        });
         debug('validation result:', validateResult);
         if (validateResult.errors.length || validateResult.warnings.length) {
           debug('emitting responseValidationError');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-node-runner",
-  "version": "0.6.16",
+  "version": "0.7.0",
   "description": "Swagger loader and middleware utilities",
   "keywords": [
     "swagger",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "multer": "^1.0.6",
     "parseurl": "^1.3.0",
     "qs": "^5.2.0",
-    "sway": "^0.6.0",
+    "sway": "^1.0.0",
     "type-is": "^1.6.9"
   },
   "devDependencies": {

--- a/test/lib/common.js
+++ b/test/lib/common.js
@@ -453,7 +453,7 @@ module.exports = function() {
         should.exist(res);
         validationResponse.errors.should.be.an.Array;
         validationResponse.errors.length.should.eql(1);
-        validationResponse.errors[0].should.eql({
+        validationResponse.errors[0].should.containDeep({
           code: 'INVALID_RESPONSE_HEADER',
           errors:
           [ { code: 'INVALID_TYPE',
@@ -484,7 +484,7 @@ module.exports = function() {
         should.exist(res);
         validationResponse.errors.should.be.an.Array;
         validationResponse.errors.length.should.eql(1);
-        validationResponse.errors[0].should.eql({
+        validationResponse.errors[0].should.containDeep({
           code: 'INVALID_RESPONSE_BODY',
           errors:
             [ { code: 'INVALID_TYPE',


### PR DESCRIPTION
Based on the discussion in #25, I have grabbed irond13's forked changes and am creating this PR to make it easier to absorb. Based on feedback from @theganyo, I did a minor bump to 0.7.0 just in case. I can pull the version change back out if needed. 

This fixes response validation checking for JSON objects which are broken with the current sway dependency. This restores that functionality. 

Resolves #25 