### PR TITLE
use request logger whenever it's available

### DIFF
--- a/fittings/json_error_handler.js
+++ b/fittings/json_error_handler.js
@@ -12,10 +12,13 @@ module.exports = function create(fittingDef, bagpipes) {
     if (!util.isError(context.error)) { return next(); }
 
     var err = context.error;
+    var log;
 
     debug('exec: %s', context.error.message);
 
     try {
+      log = context.response.log || context.request.log || console;
+      
       if (!context.statusCode || context.statusCode < 400) {
         if (context.response && context.response.statusCode && context.response.statusCode >= 400) {
           context.statusCode = context.response.statusCode;
@@ -36,6 +39,7 @@ module.exports = function create(fittingDef, bagpipes) {
       next(null, JSON.stringify(err));
     } catch (err2) {
       debug('jsonErrorHandler unable to stringify error: %j', err);
+      if (log) log.error(err2, "jsonErrorHandler unable to stringify error", err);
       next();
     }
   }

--- a/fittings/json_error_handler.js
+++ b/fittings/json_error_handler.js
@@ -16,18 +16,17 @@ module.exports = function create(fittingDef, bagpipes) {
     var body;
 
     debug('exec: %s', context.error.message);
-
       
-      if (!context.statusCode || context.statusCode < 400) {
-        if (context.response && context.response.statusCode && context.response.statusCode >= 400) {
-          context.statusCode = context.response.statusCode;
-        } else if (err.statusCode && err.statusCode >= 400) {
-          context.statusCode = err.statusCode;
-          delete(err.statusCode);
-        } else {
-          context.statusCode = 500;
-        }
+    if (!context.statusCode || context.statusCode < 400) {
+      if (context.response && context.response.statusCode && context.response.statusCode >= 400) {
+        context.statusCode = context.response.statusCode;
+      } else if (err.statusCode && err.statusCode >= 400) {
+        context.statusCode = err.statusCode;
+        delete(err.statusCode);
+      } else {
+        context.statusCode = 500;
       }
+    }
 
     try {
       //TODO: find what's throwing here...

--- a/fittings/json_error_handler.js
+++ b/fittings/json_error_handler.js
@@ -17,7 +17,7 @@ module.exports = function create(fittingDef, bagpipes) {
     debug('exec: %s', context.error.message);
 
     try {
-      log = context.response && context.response.log || context.request && context.request.log || console;
+      log = context.response && context.response.log || context.request && context.request.log;
       
       if (!context.statusCode || context.statusCode < 400) {
         if (context.response && context.response.statusCode && context.response.statusCode >= 400) {

--- a/fittings/json_error_handler.js
+++ b/fittings/json_error_handler.js
@@ -18,7 +18,11 @@ module.exports = function create(fittingDef, bagpipes) {
     debug('exec: %s', context.error.message);
 
     try {
-      log = context.response && context.response.log || context.request && context.request.log;
+      log = context.request && ( 
+               context.request.log 
+            || context.request.app && context.request.app.log
+            )
+         || context.response && context.response.log
       
       if (!context.statusCode || context.statusCode < 400) {
         if (context.response && context.response.statusCode && context.response.statusCode >= 400) {

--- a/fittings/json_error_handler.js
+++ b/fittings/json_error_handler.js
@@ -17,7 +17,7 @@ module.exports = function create(fittingDef, bagpipes) {
     debug('exec: %s', context.error.message);
 
     try {
-      log = context.response.log || context.request.log || console;
+      log = context.response && context.response.log || context.request && context.request.log || console;
       
       if (!context.statusCode || context.statusCode < 400) {
         if (context.response && context.response.statusCode && context.response.statusCode >= 400) {

--- a/fittings/json_error_handler.js
+++ b/fittings/json_error_handler.js
@@ -17,12 +17,6 @@ module.exports = function create(fittingDef, bagpipes) {
 
     debug('exec: %s', context.error.message);
 
-    try {
-      log = context.request && ( 
-               context.request.log 
-            || context.request.app && context.request.app.log
-            )
-         || context.response && context.response.log
       
       if (!context.statusCode || context.statusCode < 400) {
         if (context.response && context.response.statusCode && context.response.statusCode >= 400) {
@@ -35,6 +29,8 @@ module.exports = function create(fittingDef, bagpipes) {
         }
       }
 
+    try {
+      //TODO: find what's throwing here...
       if (context.statusCode === 500 && !fittingDef.handle500Errors) { return next(err); }
       //else - from here we commit to emitting error as JSON, no matter what.
 
@@ -44,7 +40,12 @@ module.exports = function create(fittingDef, bagpipes) {
       delete(context.error);
       next(null, JSON.stringify(err));
     } catch (err2) {
-
+      log = context.request && ( 
+               context.request.log 
+            || context.request.app && context.request.app.log
+            )
+         || context.response && context.response.log;
+    
       body = { 
         message: "unable to stringify error properly",
         stringifyErr: err2.message,

--- a/test/fittings/json_error_handler.js
+++ b/test/fittings/json_error_handler.js
@@ -170,7 +170,7 @@ describe('json_error_handler', function() {
           log: { 
             error: function() { this.lastErr = arguments } 
           }
-        }
+        },
         error: new Error('this is a test')
       }
     });
@@ -196,7 +196,7 @@ describe('json_error_handler', function() {
           log: { 
             error: function() { this.lastErr = arguments } 
           }
-        }
+        },
         error: new Error('this is a test')
       }
     });

--- a/test/fittings/json_error_handler.js
+++ b/test/fittings/json_error_handler.js
@@ -136,11 +136,11 @@ describe('json_error_handler', function() {
       mockErr.circular = mockErr; //force stringification error
     });
   
-    describe('and context has a logger on response', function() {
+    describe('and context has a logger on request', function() {
       before(function(done) {
         context = {
           headers: {},
-          response: {
+          request: {
             log: { 
               error: function() { this.lastErr = arguments } 
             }
@@ -159,18 +159,49 @@ describe('json_error_handler', function() {
           should.not.exist(context.error);
       });
       it('should pass stringification error to the logger', function() {
-          should.exist(context.response.log.lastErr, "error was not passed to log");
-          should(context.response.log.lastErr.length).eql(3);
-          should(context.response.log.lastErr[2]).equal(mockErr);
+          should.exist(context.request.log.lastErr, "error was not passed to log");
+          should(context.request.log.lastErr.length).eql(3);
+          should(context.request.log.lastErr[2]).equal(mockErr);
       });
     });
     
-    describe('and context has no logger on response, but has on request', function() {
+    describe('and context has no logger on req.log, but has on request.app.log', function() {
+      before(function(done) {
+        context = {
+          headers: {},
+          request: {
+            app: {
+              log: { 
+                error: function() { this.lastErr = arguments } 
+              }
+            }
+          },
+          error: mockErr
+        };
+        jsonErrorHandler(context, function(e) {
+            err = e;
+            done()
+        });
+      });
+      it('should not fail', function() {
+          should.not.exist(err);
+      })
+      it('should remove the error from the context', function() {
+          should.not.exist(context.error);
+      });
+      it('should pass stringification error to the logger', function() {
+          should.exist(context.request.app.log.lastErr, "error was not passed to log");
+          should(context.request.app.log.lastErr.length).eql(3);
+          should(context.request.app.log.lastErr[2]).equal(mockErr);
+      });
+    });
+    
+    describe('and context has no logger on request, but has on response', function() {
       
       beforeEach(function(done) {
         context = {
           headers: {},
-          request: {
+          response: {
             log: { 
               error: function() { this.lastErr = arguments } 
             }
@@ -191,9 +222,9 @@ describe('json_error_handler', function() {
           should.not.exist(context.error);
       });
       it('should pass stringification error to the logger', function() {
-          should.exist(context.request.log.lastErr, "error was not passed to log");
-          should(context.request.log.lastErr.length).eql(3);
-          should(context.request.log.lastErr[2]).equal(mockErr);
+          should.exist(context.response.log.lastErr, "error was not passed to log");
+          should(context.response.log.lastErr.length).eql(3);
+          should(context.response.log.lastErr[2]).equal(mockErr);
       });
     });
   });

--- a/test/fittings/json_error_handler.js
+++ b/test/fittings/json_error_handler.js
@@ -172,16 +172,17 @@ describe('json_error_handler', function() {
           }
         },
         error: new Error('this is a test')
-      }
+      };
+      context.error.circular = context.error; //force stringification error
     });
 
-    it('should pass the error to the logger', function(done) {
+    it('should pass stringification error to the logger', function(done) {
       jsonErrorHandler(context, function(err) {
         should.not.exist(err);
         should.not.exist(context.error);
         should.exist(context.response.log.error.lastErr, "error was not passed to log");
-        should(context.response.log.error.lastErr.length).eql(3)
-        should(context.request.log.error.lastErr[2]).equal(context.error)
+        should(context.response.log.error.lastErr.length).eql(3);
+        should(context.request.log.error.lastErr[2]).equal(context.error);
         done();
       });
     });
@@ -198,16 +199,17 @@ describe('json_error_handler', function() {
           }
         },
         error: new Error('this is a test')
-      }
+      };
+      context.error.circular = context.error; //force stringification error
     });
 
-    it('should pass the error to the logger', function(done) {
+    it('should pass stringification error to the logger', function(done) {
       jsonErrorHandler(context, function(err) {
         should.not.exist(err);
         should.not.exist(context.error);
         should.exist(context.request.log.error.lastErr, "error was not passed to log");
-        should(context.request.log.error.lastErr.length).eql(3)
-        should(context.request.log.error.lastErr[2]).equal(context.error)
+        should(context.request.log.error.lastErr.length).eql(3);
+        should(context.request.log.error.lastErr[2]).equal(context.error);
         done();
       });
     });

--- a/test/fittings/json_error_handler.js
+++ b/test/fittings/json_error_handler.js
@@ -160,4 +160,56 @@ describe('json_error_handler', function() {
       });
     });
   });
+  
+  describe('context has a logger in response', function() {
+    var context;
+    beforeEach(function() {
+      context = {
+        headers: {},
+        response: {
+          log: { 
+            error: function() { this.lastErr = arguments } 
+          }
+        }
+        error: new Error('this is a test')
+      }
+    });
+
+    it('should pass the error to the logger', function(done) {
+      jsonErrorHandler(context, function(err) {
+        should.not.exist(err);
+        should.not.exist(context.error);
+        should.exist(context.response.log.error.lastErr, "error was not passed to log");
+        should(context.response.log.error.lastErr.length).eql(3)
+        should(context.request.log.error.lastErr[2]).equal(context.error)
+        done();
+      });
+    });
+  });
+  
+  describe('context has no logger in response, but has in request', function() {
+    var context;
+    beforeEach(function() {
+      context = {
+        headers: {},
+        request: {
+          log: { 
+            error: function() { this.lastErr = arguments } 
+          }
+        }
+        error: new Error('this is a test')
+      }
+    });
+
+    it('should pass the error to the logger', function(done) {
+      jsonErrorHandler(context, function(err) {
+        should.not.exist(err);
+        should.not.exist(context.error);
+        should.exist(context.request.log.error.lastErr, "error was not passed to log");
+        should(context.request.log.error.lastErr.length).eql(3)
+        should(context.request.log.error.lastErr[2]).equal(context.error)
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
I'm still not sure about line 43.

I did not touch it - but I feel there's a problem there - for the least of it, it should be `next(err)` or maybe even `next(err2)`...