### PR TITLE
Convert Buffer to String before validation

### DIFF
--- a/lib/connect_middleware.js
+++ b/lib/connect_middleware.js
@@ -159,6 +159,7 @@ function hookResponseForValidation(context, eventEmitter) {
       try {
         var headers = res._headers || res.headers || {};
         var body = data || written;
+        body = Buffer.isBuffer(body) ? body.toString() : body;
         debugContent('response body type: %s value: %s', typeof body, body);
         var validateResult = context.request.swagger.operation.validateResponse({
           statusCode: res.statusCode,


### PR DESCRIPTION
### Motivation
In `hookResponseForValidation` function, validation fails when `body` is a Buffer.

### Changes
* Convert `body` from Buffer to String before validation.