### PR TITLE
Support dependencies injection in router fitting

### DIFF
--- a/fittings/swagger_router.js
+++ b/fittings/swagger_router.js
@@ -15,6 +15,7 @@ module.exports = function create(fittingDef, bagpipes) {
 
   var swaggerNodeRunner = bagpipes.config.swaggerNodeRunner;
   var appRoot = swaggerNodeRunner.config.swagger.appRoot;
+  var dependencies = swaggerNodeRunner.config.swagger.dependencies
 
   var mockMode = !!fittingDef.mockMode || !!swaggerNodeRunner.config.swagger.mockMode;
 
@@ -45,7 +46,7 @@ module.exports = function create(fittingDef, bagpipes) {
       for (var i = 0; i < controllersDirs.length; i++) {
         var controllerPath = path.resolve(controllersDirs[i], controllerName);
         try {
-          controller = require(controllerPath);
+          controller = !dependencies ? require(controllerPath) : require(controllerPath)(dependencies);
           controllerFunctionsCache[controllerName] = controller;
           debug('controller found', controllerPath);
           break;

--- a/fittings/swagger_router.js
+++ b/fittings/swagger_router.js
@@ -46,7 +46,8 @@ module.exports = function create(fittingDef, bagpipes) {
       for (var i = 0; i < controllersDirs.length; i++) {
         var controllerPath = path.resolve(controllersDirs[i], controllerName);
         try {
-          controller = !dependencies ? require(controllerPath) : require(controllerPath)(dependencies);
+          var ctrlObj = require(controllerPath)
+          controller = dependencies && typeof ctrlObj === 'function' ? ctrlObj(dependencies) : ctrlObj
           controllerFunctionsCache[controllerName] = controller;
           debug('controller found', controllerPath);
           break;

--- a/test/assets/project/api/controllers/hello_deps_injected.js
+++ b/test/assets/project/api/controllers/hello_deps_injected.js
@@ -1,0 +1,12 @@
+module.exports = function(dependencies){
+  if (!dependencies.FooFactory)
+    throw new Error('Foo Factory not found');
+  var FooFactory = dependencies.FooFactory;
+
+  return {
+    hello: function(req, res) {
+      var name = req.swagger.params.name.value;
+      res.json(FooFactory.hello(name));
+    }
+  };
+};

--- a/test/assets/project/api/swagger/swagger.yaml
+++ b/test/assets/project/api/swagger/swagger.yaml
@@ -239,6 +239,25 @@ paths:
           description: Error
           schema:
             $ref: "#/definitions/ErrorResponse"
+  /hello_injected_dependencies:
+    x-swagger-router-controller: hello_deps_injected
+    get:
+      description: Returns 'Hello' to the caller
+      operationId: hello
+      parameters:
+        - name: name
+          in: query
+          description: The name of the person to whom to say hello
+          required: false
+          type: string
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: "#/definitions/HelloWorldResponse"
+          examples:
+            application/json:
+              message: 'An example message'
   /swagger:
     x-swagger-pipe: swagger_raw
   /pipe_on_get:

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@
 var should = require('should');
 var path = require('path');
 var _ = require('lodash');
+var util = require('util');
 
 var SwaggerRunner = require('..');
 
@@ -110,17 +111,17 @@ describe('index', function() {
       });
     });
 
-    it('should create with injected dependencies', function(done) {
+    it('should create with injected dependencies controllers', function(done) {
 
       var config = _.clone(DEFAULT_PROJECT_CONFIG);
-      var FooFactory = {
+      var fooFactory = {
         hello: function(name){
           if(!name)
             name = 'stranger';
-          return `Hello, ${name}!`;
+          return util.format('Hello, %s!', name);
         }
       }
-      config.dependencies = {FooFactory}
+      config.dependencies = {FooFactory: fooFactory}
       SwaggerRunner.create(config, function(err, runner) {
         if (err) { return done(err); }
         runner.config.swagger.bagpipes.should.have.property('swagger_controllers');

--- a/test/index.js
+++ b/test/index.js
@@ -110,6 +110,39 @@ describe('index', function() {
       });
     });
 
+    it('should create with injected dependencies', function(done) {
+
+      var config = _.clone(DEFAULT_PROJECT_CONFIG);
+      var FooFactory = {
+        hello: function(name){
+          if(!name)
+            name = 'stranger';
+          return `Hello, ${name}!`;
+        }
+      }
+      config.dependencies = {FooFactory}
+      SwaggerRunner.create(config, function(err, runner) {
+        if (err) { return done(err); }
+        runner.config.swagger.bagpipes.should.have.property('swagger_controllers');
+
+        var app = require('connect')();
+        runner.connectMiddleware().register(app);
+
+        var request = require('supertest');
+
+        request(app)
+          .get('/hello_injected_dependencies')
+          .set('Accept', 'application/json')
+          .expect(200)
+          .expect('Content-Type', /json/)
+          .end(function(err, res) {
+            should.not.exist(err);
+            res.body.should.eql('Hello, stranger!');
+            done();
+          });
+      });
+    });
+
     it('should fail without callback', function() {
 
       (function() { SwaggerRunner.create(DEFAULT_PROJECT_CONFIG) }).should.throw('callback is required');


### PR DESCRIPTION
Just an idea that would make my life much easier. Let the api to [inject their dependencies](https://en.wikipedia.org/wiki/Dependency_injection). (additionally would be possible to use tools like [electrolyte](https://www.npmjs.com/package/electrolyte))

Pass dependencies to `create` by config object, example:
``` javascript
  config.dependencies = [fs, path, ...]

  SwaggerExpress.create(config, function(err, swaggerExpress) {
    if (err) {
      deps.logger.error(err)
      throw err
    }

    // install middleware
    swaggerExpress.register(app)
  })
```

The controlle's module exports will look like something like:
``` javascript
module.exports = function(dependencies){
  return {
    hello: hello,
    hello_body: hello_body,
    hello_file: hello_file,
    get: hello,
    multiple_writes: multiple_writes,
    hello_text_body: hello_text_body
  }
};
``` 