### PR TITLE
private attrs should be stripped from params too

### DIFF
--- a/fittings/swagger_raw.js
+++ b/fittings/swagger_raw.js
@@ -46,7 +46,7 @@ module.exports = function create(fittingDef, bagpipes) {
 };
 
 function filterKeysRecursive(object, dropTagRegex, privateTags) {
-  if (object && 'object' == typeof object)) {
+  if (_.isPlainObject(object)) {
     if (_.any(privateTags, function(tag) { return object[tag]; })) {
       object = undefined;
     } else {
@@ -66,6 +66,12 @@ function filterKeysRecursive(object, dropTagRegex, privateTags) {
       });
       return result;
     }
+  } else if (Array.isArray(object) ) {
+     object = object.reduce(function(reduced, value) {
+        var v = filterKeysRecursive(value, dropTagRegex, privateTags);
+        if (v !== undefined) reduced.push(v);
+        return reduced
+     }, [])
   }
   return object;
 }

--- a/fittings/swagger_raw.js
+++ b/fittings/swagger_raw.js
@@ -46,7 +46,7 @@ module.exports = function create(fittingDef, bagpipes) {
 };
 
 function filterKeysRecursive(object, dropTagRegex, privateTags) {
-  if (_.isPlainObject(object)) {
+  if (object && 'object' == typeof object)) {
     if (_.any(privateTags, function(tag) { return object[tag]; })) {
       object = undefined;
     } else {
@@ -60,6 +60,8 @@ function filterKeysRecursive(object, dropTagRegex, privateTags) {
             debug('dropping object at %s', key);
             delete(result[key]);
           }
+        } else {
+            debug("dropping value at %s", key)
         }
       });
       return result;

--- a/test/assets/project/api/swagger/swagger.yaml
+++ b/test/assets/project/api/swagger/swagger.yaml
@@ -22,6 +22,7 @@ paths:
           description: The name of the person to whom to say hello
           required: false
           type: string
+          x-remove-me: lol
       responses:
         200:
           description: Success

--- a/test/fittings/swagger_raw.js
+++ b/test/fittings/swagger_raw.js
@@ -18,6 +18,7 @@ describe('swagger_raw', function() {
 
     var filteredSwagger = _.cloneDeep(swagger);
     delete(filteredSwagger.paths['/invalid_header']);
+    delete(filteredSwagger.paths['/hello'].get.parameters[0]['x-remove-me'])
 
     // hokey algorithm, but at least it's different than the one it's testing
     var OMIT = ['x-swagger-router-controller', 'x-swagger-pipe', 'x-hidden', 'x-private', 'x-controller-interface'];


### PR DESCRIPTION
Fix bug: swagger_raw - `x-<whatever>` was not stripped from parameters.

Now it is :)