### PR TITLE
json_error_handler: cfg.includeErrStack

### DIFF
--- a/fittings/json_error_handler.js
+++ b/fittings/json_error_handler.js
@@ -35,6 +35,8 @@ module.exports = function create(fittingDef, bagpipes) {
 
       context.headers['Content-Type'] = 'application/json';
       Object.defineProperty(err, 'message', { enumerable: true }); // include message property in response
+      if (fittingDef.includeErrStack)
+          Object.defineProperty(err, 'stack', { enumerable: true }); // include stack property in response
 
       delete(context.error);
       next(null, JSON.stringify(err));

--- a/test/fittings/json_error_handler.js
+++ b/test/fittings/json_error_handler.js
@@ -123,6 +123,39 @@ describe('json_error_handler', function() {
       });
     });
   });
+  
+  describe('includeErrStack:true', function() {
+
+    var context;
+    beforeEach(function() {
+      var err = new Error('this is a test');
+      err.statusCode = 401;
+      err.someAttr = 'value';
+      context = {
+        headers: {},
+        error: err
+      };
+    });
+    
+    it('should allow the stack in the response body', function(done) {
+
+      var jsonErrorHandler = json_error_handler({ includeErrStack: true });
+
+      jsonErrorHandler(context, function(err, output) {
+        should.not.exist(err);
+        should.not.exist(context.error);
+
+        var e;
+        try {
+          var body = JSON.parse(output);
+          body.should.have.property('message', 'this is a test');
+          body.should.have.property('someAttr','value');
+          body.should.have.property('stack')
+        } catch(x) { e = x }
+        done(e)
+      });
+    })
+  })
 
   describe('handle500Errors:true and error fails to stringify', function() { 
     var jsonErrorHandler;


### PR DESCRIPTION
Support flag for development and integration environments: includeErrStack
```
    openapi-error: 
      name:                 json_error_handler
      handle500Errors:      true
      includeErrStack:      true

```
When truthful, the automatic response-body includes the stack as well as any other enumerable attribute on the error
Change is backward compatible (missing config is understood as the default - false)

