### PR TITLE
middleware chain is broken when found ctx.output

### DIFF
--- a/lib/connect_middleware.js
+++ b/lib/connect_middleware.js
@@ -89,9 +89,9 @@ function Middleware(runner) {
 
               debugContent('sending response body: %s', body);
               response.end(body);
-            } else {
-              next();
-            }
+            } 
+            
+            next();
           }
           catch (err) {
             /* istanbul ignore next */


### PR DESCRIPTION
I'm not sure about this - I need your eyes here.
If I'm on target - I'll add tests so you can merge.

.

I'm using restify, and I have other mw on the chain after the swagger_router.
(e.g `server.on('after', restify.auditLogger(options.auditLogCfg));` )

I first noted that when I dont use `json_error_handler` - I get the audit entry on requests that error, and when I do - I dont get the desired log entries.
(e.g. - the 'after' event is not emitted - that suggests that the mw chain is broken)

Then I noted that they are emitted with `defaultErrorHandler` and are not emitted with `json_error_handler` because it creates `ctx.output`, where `defaultErrorHandler` does not.

The research led me to the corrected lines.
Let me know what you think.