### PR TITLE
Revert "middleware chain is broken when found ctx.output"  Fix #80.

### DIFF
--- a/lib/connect_middleware.js
+++ b/lib/connect_middleware.js
@@ -89,9 +89,9 @@ function Middleware(runner) {
 
               debugContent('sending response body: %s', body);
               response.end(body);
-            } 
-            
-            next();
+            } else {
+              next();
+            }
           }
           catch (err) {
             /* istanbul ignore next */


### PR DESCRIPTION
This reverts commit ac6dad9fb5071bddd7a95c32cc38e9cc15c57228.

The original commit causes a server-side error when express's default 404
handler gets invoked after the response is set.  The default 404 handler
attempts to set the status code header, which can't be done since those
bits have already been sent.