### PR TITLE
Adds static500Error config option to hide 500 error messages from clients

### DIFF
--- a/fittings/json_error_handler.js
+++ b/fittings/json_error_handler.js
@@ -37,7 +37,9 @@ module.exports = function create(fittingDef, bagpipes) {
       Object.defineProperty(err, 'message', { enumerable: true }); // include message property in response
       if (fittingDef.includeErrStack)
           Object.defineProperty(err, 'stack', { enumerable: true }); // include stack property in response
-
+      if (fittingDef.static500Error)
+          err.message = fittingDef.static500Error
+      
       delete(context.error);
       next(null, JSON.stringify(err));
     } catch (err2) {


### PR DESCRIPTION
I wanted to hide 500 error messages from my clients, not just the stacktrace, but the message text itself. Not being familiar with this code, this seemed the most obvious way. I added a `static500Error` option to the config.

My configuration adds a static 'Internal Server Error' message:

    _json_error_handler:
      name: json_error_handler
      handle500Errors: true
      static500Error: Internal Server Error
      includeErrStack: false

    swagger_controllers:
      - onError: _json_error_handler
      - cors
      - swagger_params_parser
      - swagger_security
      - _swagger_validate
      - express_compatibility
      - _router