### PR TITLE
Update hapi_middleware.js

### DIFF
--- a/lib/hapi_middleware.js
+++ b/lib/hapi_middleware.js
@@ -20,7 +20,7 @@ function Hapi(runner) {
 
       server.ext('onRequest', function(request, reply) {
 
-        var req = request.raw.req;
+        var req = request;
         var res = newResponse(reply);
 
         chain(req, res, function(err) {


### PR DESCRIPTION
Use the hapi request object as the basis for this middleware.  Allows multiple middlewares to be used with swagger-hapi

As per issue #99 