### PR TITLE
fix: operation ends with next(null, null) gets 404

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "stable"
+  - "6"
   - "4.0"
   - "0.12"
   - "0.10"

--- a/lib/connect_middleware.js
+++ b/lib/connect_middleware.js
@@ -84,7 +84,7 @@ function Middleware(runner) {
               });
             }
 
-            if (undefined !== context.output) { return next(); }
+            if (undefined === context.output) { return next(); }
 
             var contentType = response.getHeader('content-type');
             if (!contentType) {

--- a/lib/connect_middleware.js
+++ b/lib/connect_middleware.js
@@ -84,7 +84,7 @@ function Middleware(runner) {
               });
             }
 
-            if (!context.output) { return next(); }
+            if (undefined !== context.output) { return next(); }
 
             var contentType = response.getHeader('content-type');
             if (!contentType) {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "istanbul": "^0.4.0",
     "mocha": "^2.3.0",
     "mocha-lcov-reporter": "^1.0.0",
-    "restify": "^4.0.3",
+    "restify": "^5.2.0",
     "should": "^7.1.0",
     "sinon": "^1.17.2",
     "supertest": "^1.1.0"

--- a/test/assets/project/api/controllers/overrides_ctrl_interface_pipe.js
+++ b/test/assets/project/api/controllers/overrides_ctrl_interface_pipe.js
@@ -1,6 +1,7 @@
 module.exports = {
   pipeInterface:       pipeInterface,
-  middlewareInterface: middlewareInterface
+  middlewareInterface: middlewareInterface,
+  pipeInterfaceNoBody: pipeInterfaceNoBody
 }
 
 function pipeInterface(ctx, next) {
@@ -15,4 +16,13 @@ function pipeInterface(ctx, next) {
 function middlewareInterface(req, res, next) {
   res.setHeader('x-interface', 'middleware');
   res.json({ interface: "middleware" });
+}
+
+function pipeInterfaceNoBody(ctx, next) {
+  ctx.statusCode = 200;
+  ctx.headers = { 
+    'content-type': 'application/json',
+    'x-interface': 'pipe'
+  };
+  next(null, null);
 }

--- a/test/assets/project/api/swagger/swagger.yaml
+++ b/test/assets/project/api/swagger/swagger.yaml
@@ -354,6 +354,19 @@ paths:
         200: 
           description: Whatever
           schema: {}
+  /controller_interface_pipe_operation_with_no_body:
+    x-swagger-router-controller: overrides_ctrl_interface_pipe
+    get:
+      x-controller-interface: pipe
+      operationId: pipeInterfaceNoBody
+      responses:
+        200:
+          description: Success
+        default:
+          description: Error
+          schema:
+            $ref: "#/definitions/ErrorResponse"         
+
 definitions:
   HelloWorldResponse:
     type: object

--- a/test/index.js
+++ b/test/index.js
@@ -375,6 +375,30 @@ describe('index', function() {
           });
       });
     });
+    
+    it('should accept null body from pipe interface', function(done) {
+      var config = _.clone(DEFAULT_PROJECT_CONFIG);
+      config.configDir = path.resolve(DEFAULT_PROJECT_ROOT, "config_auto");
+
+      SwaggerRunner.create(config, function(err, runner) {
+        if (err) { return done(err); }
+        runner.config.swagger.bagpipes.should.have.property('swagger_controllers');
+
+        var app = require('connect')();
+        runner.connectMiddleware().register(app);
+
+        var request = require('supertest');
+
+        request(app)
+          .get('/controller_interface_pipe_operation_with_no_body')
+          .set('Accept', 'application/json')
+          .expect(200)
+          .end(function(err, res) {
+            should.not.exist(err, err && err.stack);
+            done();
+          });
+      });
+    });
 
 
     it('should fail without callback', function() {


### PR DESCRIPTION
bug fix,
when an operation controller method ends with 
```

    ctx.statusCode = 200
    next(null, null)
```
The response is yet 404 - because the mw does not understand the operation actually worked