### PR TITLE
Allow mocks for paths without a controllerName

### DIFF
--- a/fittings/swagger_router.js
+++ b/fittings/swagger_router.js
@@ -59,7 +59,7 @@ module.exports = function create(fittingDef, bagpipes) {
       debug('controller in cache', controllerName);
       controller = controllerFunctionsCache[controllerName];
 
-    } else {
+    } else if (controllerName) {
 
       debug('loading controller %s from fs: %s', controllerName, controllersDirs);
       for (var i = 0; i < controllersDirs.length; i++) {


### PR DESCRIPTION
Fixes #118 

This means, for example, that if you set `defaultPipe: swagger_controllers` and `controllerName ` is `undefined`, then it skips looking for a controller (as `path.resolve(controllersDirs[i], controllerName)` would error) and continues to making a mock.