### PR TITLE
swagger router - default response for mock

### DIFF
--- a/fittings/swagger_router.js
+++ b/fittings/swagger_router.js
@@ -123,7 +123,8 @@ module.exports = function create(fittingDef, bagpipes) {
       if (mock) {
         debug('returning mock example value', mock);
       } else {
-        mock = operation.getResponse(statusCode).getSample();
+        var operationResponse = operation.getResponse(statusCode) || operation.getResponse('default');
+        mock = operationResponse.getSample();
         debug('returning mock sample value', mock);
       }
 

--- a/fittings/swagger_router.js
+++ b/fittings/swagger_router.js
@@ -117,7 +117,8 @@ module.exports = function create(fittingDef, bagpipes) {
       var statusCode = parseInt(context.request.get('_mockreturnstatus')) || 200;
 
       var mimetype = context.request.get('accept') || 'application/json';
-      var mock = operation.getResponse(statusCode).getExample(mimetype);
+      var response  = operation.getResponse(statusCode) || operation.getResponse('default');
+      var mock = response.getExample(mimetype);
 
       if (mock) {
         debug('returning mock example value', mock);


### PR DESCRIPTION
Use default response for mock if statusCode response not available

Fixes #120 