### PR TITLE
Issue #87: Do not call 'next()' after writing message body.

### DIFF
--- a/lib/connect_middleware.js
+++ b/lib/connect_middleware.js
@@ -97,8 +97,6 @@ function Middleware(runner) {
 
             debugContent('sending response body: %s', body);
             response.end(body);
-
-            next();
           }
           catch (err) {
             /* istanbul ignore next */


### PR DESCRIPTION
Fixes #87.