### PR TITLE
Add config option to supress console warning messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -218,7 +218,9 @@ function Runner(appJsConfig, cb) {
       if (warnings && warnings.length > 0) {
         var warningText = JSON.stringify(warnings);
         if (self.config.swagger.startWithWarnings) {
-          console.error(warningText, 2);
+          if(!self.config.swagger.suppressWarnings) {
+            console.error(warningText, 2);
+		  }
         } else {
           var err = new Error('Swagger validation warnings:');
           err.validationWarnings = warnings;
@@ -245,7 +247,7 @@ function Runner(appJsConfig, cb) {
           console.error("\t#" + i + ".: " + err.validationErrors[i].message + " in swagger config at: >" + err.validationErrors[i].path.join('/') + "<");
         }
       }
-      
+
       process.nextTick(function() { throw err; });
     })
 }

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ var should = require('should');
 var path = require('path');
 var _ = require('lodash');
 var util = require('util');
+var sinon = require('sinon');
 
 var SwaggerRunner = require('..');
 
@@ -375,7 +376,7 @@ describe('index', function() {
           });
       });
     });
-    
+
     it('should accept null body from pipe interface', function(done) {
       var config = _.clone(DEFAULT_PROJECT_CONFIG);
       config.configDir = path.resolve(DEFAULT_PROJECT_ROOT, "config_auto");
@@ -399,7 +400,6 @@ describe('index', function() {
           });
       });
     });
-
 
     it('should fail without callback', function() {
       (function() { SwaggerRunner.create(DEFAULT_PROJECT_CONFIG) }).should.throw('callback is required');
@@ -445,11 +445,29 @@ describe('index', function() {
 
   it('should continue with swagger warnings if startWithWarnings is true', function(done) {
     var config = _.clone(DEFAULT_PROJECT_CONFIG);
+    sinon.spy(console, 'error');
     config.startWithWarnings = true;
     config.swagger = SWAGGER_WITH_WARNINGS;
     SwaggerRunner.create(config, function(err, runner) {
       should.not.exist(err);
+      console.error.calledOnce.should.be.true();
+      console.error.calledWith('[{"code":"UNUSED_DEFINITION","message":"Definition is not used: #/definitions/SomeUnusedDefinition","path":["definitions","SomeUnusedDefinition"]}]').should.be.true();
+      console.error.restore();
       done();
+    });
+  });
+
+  it('should continue with swagger warnings and not show error in console if startWithWarnings is true and suppressWarnings is true', function(done) {
+    var config = _.clone(DEFAULT_PROJECT_CONFIG);
+    sinon.spy(console, 'error');
+    config.startWithWarnings = true;
+    config.suppressWarnings = true;
+    config.swagger = SWAGGER_WITH_WARNINGS;
+    SwaggerRunner.create(config, function(err, runner) {
+        should.not.exist(err);
+        console.error.notCalled.should.be.true();
+		console.error.restore();
+        done();
     });
   });
 


### PR DESCRIPTION
We have `startWithWarnings` option to start the app. If we choose to start with the warnings, its looks ugly in the logs to have those warnings shown as errors. Users get confused when see the warnings in the console logs and feel application is not in good state. 

So added an option `suppressWarnings` to disable those console log messages for only warnings. 