### PR TITLE
Upgrade Sway to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "multer": "^1.0.6",
     "parseurl": "^1.3.0",
     "qs": "^6.4.0",
-    "sway": "^1.0.0",
+    "sway": "^2.0.0",
     "type-is": "^1.6.9"
   },
   "devDependencies": {


### PR DESCRIPTION
Personally, I need this as it contains the following fixes:

  apigee-127/sway#174 failing tests with json-schema-faker@0.5.0-rc13
  apigee-127/sway#165 UNRESOLVABLE_REFERENCE for circular references
  apigee-127/sway#168 Add date and time format support to mocks

This is so that I can start using swagger-node-runner in openapi-mock rather than my temporary fork.

 https://github.com/penx/openapi-mock/issues/5
